### PR TITLE
Change in Distribution base class

### DIFF
--- a/Contributors_Only/Source/Distributions/Continuous/Cauchy.h
+++ b/Contributors_Only/Source/Distributions/Continuous/Cauchy.h
@@ -16,7 +16,7 @@ namespace DiceForge {
             Cauchy(real_t x0 = 0, real_t gamma = 1);
             /// @brief Returns the next value of the random variable described by the distribution
             /// @param r A random real number uniformly distributed between 0 and 1
-            real_t next(real_t r) override final;
+            real_t next(real_t r);
             /// @brief Returns the theoretical variance of the distribution
             /// @note The variation of a Cauchy distribution is undefined
             /// @returns NaN

--- a/Contributors_Only/Source/Distributions/Continuous/Exponential.h
+++ b/Contributors_Only/Source/Distributions/Continuous/Exponential.h
@@ -13,7 +13,7 @@ namespace DiceForge
     public:
         Exponential(real_t k);
 
-        real_t next(real_t r) override final;
+        real_t next(real_t r);
         real_t variance() const override final;
         real_t expectation() const override final;
         real_t minValue() const override final;

--- a/Contributors_Only/Source/Distributions/Discrete/Gibbs.h
+++ b/Contributors_Only/Source/Distributions/Discrete/Gibbs.h
@@ -22,7 +22,7 @@ namespace DiceForge {
             ~Gibbs();
             /* next(r) [Integer] - Returns a random integer following the distribution given a 'r'
              * r is a uniformly distributed unit random variable */
-            int_t next(real_t r) override;
+            int_t next(real_t r);
             /* variance() [Real] - Returns the variance of the distribution */
             real_t variance() const override;
             /* expectation() [Real] - Returns the expectation value of the distribution */

--- a/Contributors_Only/Source/Distributions/Discrete/NegHypergeometric.h
+++ b/Contributors_Only/Source/Distributions/Discrete/NegHypergeometric.h
@@ -20,7 +20,7 @@ namespace DiceForge {
             ~NegHypergeometric();
             /// @brief Returns the next value of the random variable described by the distribution
             /// @param r A random real number uniformly distributed between 0 and 1
-            int_t next(real_t r) override final;
+            int_t next(real_t r);
             /// @brief Returns the theoretical variance of the distribution
             real_t variance() const override final;
             /// @brief Returns the theoretical expectation value of the distribution

--- a/Contributors_Only/Source/Distributions/Discrete/hypergeometric.h
+++ b/Contributors_Only/Source/Distributions/Discrete/hypergeometric.h
@@ -28,7 +28,7 @@ namespace DiceForge
         // constraints-(n<=N and k<=N and n>=0 and k>=0)
     public:
         Hypergeometric(int32_t N, int32_t K, int32_t n); // constructor for hypergeometric class
-        int_t next(real_t r) override;
+        int_t next(real_t r);
         real_t variance() const override;
         real_t expectation() const override;
         int_t minValue() const override;

--- a/Contributors_Only/Source/Distributions/distribution.h
+++ b/Contributors_Only/Source/Distributions/distribution.h
@@ -10,9 +10,6 @@ namespace DiceForge
     class Continuous
     {
     public:
-        /// @brief Returns the next value (real) of the random variable described by the distribution
-        /// @param r A random real number uniformly distributed between 0 and 1
-        virtual real_t next(real_t r) = 0;
         /// @brief Returns the theoretical variance of the distribution
         virtual real_t variance() const = 0;
         /// @brief Returns the theoretical expectation value of the distribution
@@ -33,9 +30,6 @@ namespace DiceForge
     class Discrete
     {
     public:
-        /// @brief Returns the next value (integer) of the random variable described by the distribution
-        /// @param r A random real number uniformly distributed between 0 and 1
-        virtual int_t next(real_t r) = 0;
         /// @brief Returns the theoretical variance of the distribution
         virtual real_t variance() const = 0;
         /// @brief Returns the theoretical expectation value of the distribution


### PR DESCRIPTION
Gaussian distribution requires two idd unit random variables r1 and r2 to perform Box Muller transform.
The currently defined next() method only takes in one random real number.
So next() method is no longer a part of the Discrete/Continuous base class. It is left for the classes which inherit from the base class to decide.
I have accordingly made changes in all existing distributions.